### PR TITLE
Ошибка обработки событий

### DIFF
--- a/plugins/p_ping/plugin.php
+++ b/plugins/p_ping/plugin.php
@@ -58,7 +58,8 @@ class p_ping extends cmsPlugin {
                 $pageURL = HOST .'/'. $item['seolink'] . '.html';
                 $feedURL = HOST . '/rss/content/all/feed.rss';
                 $this->ping($pageURL, $feedURL);
-
+            break;
+             
             case 'ADD_BOARD_DONE':
                 $pageURL = HOST . '/board/read'.$item['id'].'.html';
                 $feedURL = HOST . '/rss/board/all/feed.rss';


### PR DESCRIPTION
Пропущен break;  Ошибка, из за которой происходит пинг с несуществующей записью доски об'явлений (с ID добавленной статьи)
